### PR TITLE
Fix NRE for Linux authentication

### DIFF
--- a/Core/ExchangeServiceBase.cs
+++ b/Core/ExchangeServiceBase.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Exchange.WebServices.Data
                 return serviceCredentials;
 
             var networkCredentials = ((WebCredentials)serviceCredentials).Credentials as NetworkCredential;
-            if (networkCredentials != null)
+            if (url != null && networkCredentials != null)
             {
                 CredentialCache credentialCache = new CredentialCache();
                 credentialCache.Add(url, "NTLM", networkCredentials);


### PR DESCRIPTION
Fix error: 
> Microsoft.Exchange.WebServices.Data.ServiceLocalException: The Url property on the ExchangeService object must be set.    at Microsoft.Exchange.WebServices.Data.ExchangeService.Validate() in /s/l/CaseMap/ews-managed-api/Core/ExchangeService.cs:line 5005    at Microsoft.Exchange.WebServices.Data.ServiceRequestBase.Validate() in /s/l/CaseMap/ews-managed-api/Core/Requests/ServiceRequestBase.cs:line 198    at Microsoft.Exchange.WebServices.Data.ConvertIdRequest.Validate() in /s/l/CaseMap/ews-managed-api/Core/Requests/ConvertIdRequest.cs:line 102    at Microsoft.Exchange.WebServices.Data.ServiceRequestBase.ValidateAndEmitRequest(CancellationToken token) in /s/l/CaseMap/ews-managed-api/Core/Requests/ServiceRequestBase.cs:line 660    at Microsoft.Exchange.WebServices.Data.SimpleServiceRequestBase.InternalExecuteAsync(CancellationToken token) in /s/l/CaseMap/ews-managed-api/Core/Requests/SimpleServiceRequestBase.cs:line 57    at Microsoft.Exchange.WebServices.Data.MultiResponseServiceRequest`1.ExecuteAsync(CancellationToken token) in /s/l/CaseMap/ews-managed-api/Core/Requests/MultiResponseServiceRequest.cs:line 134    --- End of inner exception stack trace ---    at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)    at CaseMap.Modules.Email.Exchange.Services.ExchangeClient.HandleThrottling[T](Func`1 func) in /s/l/CaseMap/CaseMap.Modules.Email.Exchange/Services/ExchangeClient.cs:line 175    at CaseMap.Modules.Email.Exchange.Services.ExchangeClient.TestExchangeService(ExchangeService service) in /s/l/CaseMap/CaseMap.Modules.Email.Exchange/Services/ExchangeClient.cs:line 95    at CaseMap.Modules.Email.Exchange.Services.ExchangeAuthorizationService.Authorize(ExchangeAuthorizeRequest authorizeRequest) in /s/l/CaseMap/CaseMap.Modules.Email.Exchange/Services/ExchangeAuthorizationService.cs:line 62    at CaseMap.Modules.Email.Exchange.Controllers.ExchangeController.Authorize(ExchangeAuthorizeRequest authorizeRequest) in /s/l/CaseMap/CaseMap.Modules.Email.Exchange/Controllers/ExchangeController.cs:line 36 | Microsoft.Exchange.WebServices.Data.ServiceLocalException: The Url property on the ExchangeService object must be set.    at Microsoft.Exchange.WebServices.Data.ExchangeService.Validate() in /s/l/CaseMap/ews-managed-api/Core/ExchangeService.cs:line 5005    at Microsoft.Exchange.WebServices.Data.ServiceRequestBase.Validate() in /s/l/CaseMap/ews-managed-api/Core/Requests/ServiceRequestBase.cs:line 198    at Microsoft.Exchange.WebServices.Data.ConvertIdRequest.Validate() in /s/l/CaseMap/ews-managed-api/Core/Requests/ConvertIdRequest.cs:line 102    at Microsoft.Exchange.WebServices.Data.ServiceRequestBase.ValidateAndEmitRequest(CancellationToken token) in /s/l/CaseMap/ews-managed-api/Core/Requests/ServiceRequestBase.cs:line 660    at Microsoft.Exchange.WebServices.Data.SimpleServiceRequestBase.InternalExecuteAsync(CancellationToken token) in /s/l/CaseMap/ews-managed-api/Core/Requests/SimpleServiceRequestBase.cs:line 57    at Microsoft.Exchange.WebServices.Data.MultiResponseServiceRequest`1.ExecuteAsync(CancellationToken token) in /s/l/CaseMap/ews-managed-api/Core/Requests/MultiResponseServiceRequest.cs:line 134

Fix for version [1.1.3](https://github.com/AndreyVoronkovPravo/ews-managed-api/commit/3f8d40ec6b131d1857bd0362a9cd64f3c11d2bec)